### PR TITLE
PHP errors fix and crashing of woocommerce product importer page

### DIFF
--- a/Changelogs.txt
+++ b/Changelogs.txt
@@ -1,5 +1,11 @@
 == Changelog ==
 
+= 1.2.6 - 25 July, 2023 =
+- Fixed: Crashing of WooCommerce product importer page when the plugin is active.
+- Fixed: PHP Deprecated:  Function get_page_by_title is <strong>deprecated</strong> since version 6.2.0! Use WP_Query instead.
+- Fixed: PHP Notice:  Undefined variable: installed_demos.
+- Updated: Removed block widgets when importing a demo.
+
 = 1.2.5 - 23 January, 2022 =
 - Tested: WordPress version 5.9
 - Tested: PHP version 7.4

--- a/includes/demo-importer/admin/class-tt-admin-demo-config.php
+++ b/includes/demo-importer/admin/class-tt-admin-demo-config.php
@@ -1,126 +1,127 @@
 <?php
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
 
 class TT_Admin_Demo_Config {
 
-    private $theme = '';
-    private $import_class = '';
+	private $theme = '';
+	private $import_class = '';
 
-    public function __construct() {
+	public function __construct() {
 
-        $this->theme = wp_get_theme();
-        add_filter('et-demo-content-import', array($this, 'import_files'));
-        add_action('et-after-demo-content-import', array($this, 'after_import'));
-    }
+		$this->theme = wp_get_theme();
+		add_filter('et-demo-content-import', array($this, 'import_files'));
+		add_action('et-after-demo-content-import', array($this, 'after_import'));
+	}
 
-    private function get_import_class() {
+	private function get_import_class() {
 
-        $supported_themes = $this->supported_themes();
-        $demo_class = '';
-        foreach ($supported_themes as $theme) {
+		$supported_themes = $this->supported_themes();
+		$demo_class = '';
+		foreach ($supported_themes as $theme) {
 
-            $theme_name = isset($theme['theme_name']) ? $theme['theme_name'] : '';
-            
-            if (trim($theme_name) === trim($this->theme)) {
+			$theme_name = isset($theme['theme_name']) ? $theme['theme_name'] : '';
+			
+			if (trim($theme_name) === trim($this->theme)) {
 
-                $demo_class = isset($theme['demo_class']) ? $theme['demo_class'] : '';
-                break;
-            }
-        }
+				$demo_class = isset($theme['demo_class']) ? $theme['demo_class'] : '';
+				break;
+			}
+		}
 
-        return $demo_class;
-    }
+		return $demo_class;
+	}
 
-    private function supported_themes() {
+	private function supported_themes() {
 
-        return array(
+		return array(
 
-            'royale_news' => array(
-                'theme_name' => 'Royale News',
-                'demo_class' => 'TT_Theme_Demo_Royale_News',
-            ),
-            'style_blog' => array(
-                'theme_name' => 'StyleBlog',
-                'demo_class' => 'TT_Theme_Demo_Style_Blog',
-            ),
-            'style_blog_fame' => array(
-                'theme_name' => 'Style Blog Fame',
-                'demo_class' => 'TT_Theme_Demo_Style_Blog_Fame',
-            ),
-            'cream_blog' => array(
-                'theme_name' => 'Cream Blog',
-                'demo_class' => 'TT_Theme_Demo_Cream_Blog',
-            ),
-            'styleblog_plus' => array(
-                'theme_name' => 'StyleBlog Plus',
-                'demo_class' => 'TT_Theme_Demo_StyleBlog_Plus',
-            ),
-            'royale_news_pro' => array(
-                'theme_name' => 'Royale News Pro',
-                'demo_class' => 'TT_Theme_Demo_Royale_News_Pro',
-            ),
-            'cream_magazine' => array(
-                'theme_name' => 'Cream Magazine',
-                'demo_class' => 'TT_Theme_Demo_Cream_Magazine',
-            ),
-            'cream_magazine_pro' => array(
-                'theme_name' => 'Cream Magazine Pro',
-                'demo_class' => 'TT_Theme_Demo_Cream_Magazine_Pro',
-            ),
-            'royale_news_lite' => array(
-                'theme_name' => 'Royale News Lite',
-                'demo_class' => 'TT_Theme_Demo_Royale_News_Lite',
-            ),
-            'cream_blog_lite' => array(
-                'theme_name' => 'Cream Blog Lite',
-                'demo_class' => 'TT_Theme_Demo_Cream_Blog_Lite',
-            ),
-            'cream_blog_pro' => array(
-                'theme_name' => 'Cream Blog Pro',
-                'demo_class' => 'TT_Theme_Demo_Cream_Blog_Pro',
-            ),
-            'fascinate' => array(
-                'theme_name' => 'Fascinate',
-                'demo_class' => 'TT_Theme_Demo_Fascinate',
-            ),
-            'fascinate_pro' => array(
-                'theme_name' => 'Fascinate Pro',
-                'demo_class' => 'TT_Theme_Demo_Fascinate_Pro',
-            ),
-            'orchid_store' => array(
-                'theme_name' => 'Orchid Store',
-                'demo_class' => 'TT_Theme_Demo_Orchid_Store',
-            ),
-        );
-    }
+			'royale_news' => array(
+				'theme_name' => 'Royale News',
+				'demo_class' => 'TT_Theme_Demo_Royale_News',
+			),
+			'style_blog' => array(
+				'theme_name' => 'StyleBlog',
+				'demo_class' => 'TT_Theme_Demo_Style_Blog',
+			),
+			'style_blog_fame' => array(
+				'theme_name' => 'Style Blog Fame',
+				'demo_class' => 'TT_Theme_Demo_Style_Blog_Fame',
+			),
+			'cream_blog' => array(
+				'theme_name' => 'Cream Blog',
+				'demo_class' => 'TT_Theme_Demo_Cream_Blog',
+			),
+			'styleblog_plus' => array(
+				'theme_name' => 'StyleBlog Plus',
+				'demo_class' => 'TT_Theme_Demo_StyleBlog_Plus',
+			),
+			'royale_news_pro' => array(
+				'theme_name' => 'Royale News Pro',
+				'demo_class' => 'TT_Theme_Demo_Royale_News_Pro',
+			),
+			'cream_magazine' => array(
+				'theme_name' => 'Cream Magazine',
+				'demo_class' => 'TT_Theme_Demo_Cream_Magazine',
+			),
+			'cream_magazine_pro' => array(
+				'theme_name' => 'Cream Magazine Pro',
+				'demo_class' => 'TT_Theme_Demo_Cream_Magazine_Pro',
+			),
+			'royale_news_lite' => array(
+				'theme_name' => 'Royale News Lite',
+				'demo_class' => 'TT_Theme_Demo_Royale_News_Lite',
+			),
+			'cream_blog_lite' => array(
+				'theme_name' => 'Cream Blog Lite',
+				'demo_class' => 'TT_Theme_Demo_Cream_Blog_Lite',
+			),
+			'cream_blog_pro' => array(
+				'theme_name' => 'Cream Blog Pro',
+				'demo_class' => 'TT_Theme_Demo_Cream_Blog_Pro',
+			),
+			'fascinate' => array(
+				'theme_name' => 'Fascinate',
+				'demo_class' => 'TT_Theme_Demo_Fascinate',
+			),
+			'fascinate_pro' => array(
+				'theme_name' => 'Fascinate Pro',
+				'demo_class' => 'TT_Theme_Demo_Fascinate_Pro',
+			),
+			'orchid_store' => array(
+				'theme_name' => 'Orchid Store',
+				'demo_class' => 'TT_Theme_Demo_Orchid_Store',
+			),
+		);
+	}
 
 
-    public function import_files() {
+	public function import_files() {
 
-        $import_class = $this->get_import_class();
+		$import_class = $this->get_import_class();
 
-        if (empty($import_class)) {
+		if (empty($import_class)) {
 
-            return array();
-        }
+			return array();
+		}
 
-        return $import_class::import_files();
-    }
+		return $import_class::import_files();
+	}
 
-    public function after_import( $selected_import ) {
+	public function after_import( $selected_import ) {
 
-        $import_class = $this->get_import_class();
+		$import_class = $this->get_import_class();
 
-        if (empty($import_class)) {
+		if (empty($import_class)) {
 
-            return '';
-        }
+			return '';
+		}
 
-        $import_class::after_import($selected_import);
-    }
+		$import_class::after_import($selected_import);
+	}
 }
+
 
 new TT_Admin_Demo_Config();

--- a/includes/demo-importer/admin/class-tt-admin.php
+++ b/includes/demo-importer/admin/class-tt-admin.php
@@ -18,7 +18,7 @@ class TT_Admin {
 
 			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 		} else {
-
+			
 			$this->includes();
 
 			TT_Main::getInstance();

--- a/includes/demo-importer/class-themebeez-demo-importer.php
+++ b/includes/demo-importer/class-themebeez-demo-importer.php
@@ -167,6 +167,9 @@ if( ! class_exists( 'Themebeez_Demo_Importer' ) ) {
 		 * Include required core files used in admin and on the frontend.
 		 */
 		public function includes() {
+
+			global $pagenow;
+
 			/**
 			 * Class autoloader.
 			 */
@@ -252,7 +255,7 @@ if( ! class_exists( 'Themebeez_Demo_Importer' ) ) {
 		 * @return string
 		 */
 		public function ajax_url() {
-			
+
 			return admin_url( 'admin-ajax.php', 'relative' );
 		}
 	}

--- a/includes/demo-importer/class-tt-autoloader.php
+++ b/includes/demo-importer/class-tt-autoloader.php
@@ -78,11 +78,10 @@ class TT_Autoloader {
 		if ( 0 === strpos( $class, 'tt_theme_demo' ) ) {
 
 			$path = $this->include_path . 'theme-demo/';
-		} else if ( 0 === strpos( $class, 'tt_admin' ) ) {
+		} elseif ( 0 === strpos( $class, 'tt_admin' ) ) {
 
 			$path = $this->include_path . 'admin/';
-		} else if ( 0 === strpos( $class, 'tt_importer' ) ) {
-
+		} elseif ( 0 === strpos( $class, 'tt_importer' ) ) {
 			$path = $this->include_path . 'importer/';
 		} else {
 
@@ -95,5 +94,6 @@ class TT_Autoloader {
 		}
 	}
 }
+
 
 new TT_Autoloader();

--- a/includes/demo-importer/class-tt-logger.php
+++ b/includes/demo-importer/class-tt-logger.php
@@ -6,12 +6,12 @@
 // Include files.
 if ( ! class_exists( 'TT_Importer_Logger' ) ) {
 
-	require TT_ABSPATH. 'includes/demo-importer/importer/class-et-importer-logger.php';
+	require TT_ABSPATH. 'includes/demo-importer/importer/class-tt-importer-logger.php';
 }
 
 if ( ! class_exists( 'TT_Importer_Logger_CLI' ) ) {
 
-	require TT_ABSPATH. 'includes/demo-importer/importer/class-et-importer-logger-cli.php';
+	require TT_ABSPATH. 'includes/demo-importer/importer/class-tt-importer-logger-cli.php';
 }
 
 

--- a/includes/demo-importer/importer/class-tt-importer-wxr-importer.php
+++ b/includes/demo-importer/importer/class-tt-importer-wxr-importer.php
@@ -1315,7 +1315,7 @@ class TT_Importer_WXR_Importer {
 			if ( $post_exists ) {
 				$existing = $this->comment_exists( $comment );
 				if ( $existing ) {
-					$this->mapping['comment'][ $original_id ] = $exists;
+					$this->mapping['comment'][ $original_id ] = $existing;
 					continue;
 				}
 			}

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-blog-lite.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-blog-lite.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Cream_Blog_Lite extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/cream-blog-lite/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'contents.xml',
@@ -26,21 +26,21 @@ class TT_Theme_Demo_Cream_Blog_Lite extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
 
-	    $travel_category		= get_term_by( 'slug', 'travel', 'category' );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+			)
+		);
 
-	   	$banner_cats = array( $travel_category->term_id );
+		$travel_category = get_term_by( 'slug', 'travel', 'category' );
 
-	   	set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
+		$banner_cats = array( $travel_category->term_id );
 
-		update_option( 'themebeez_themes', $installed_demos );
+		set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-blog-pro.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-blog-pro.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Cream_Blog_Pro extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/cream-blog-pro/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -82,106 +82,110 @@ class TT_Theme_Demo_Cream_Blog_Pro extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-	    $import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
+		update_option( 'widget_block', array() );
 
-	    if( !empty( $import_file_name ) ) {
+		$import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
 
-	    	if( $import_file_name == 'Demo One' || $import_file_name == 'Demo Two' || $import_file_name == 'Demo Three' ) {
+		if ( ! empty( $import_file_name ) ) {
 
-	    		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
+			if (
+				'Demo One' === $import_file_name ||
+				'Demo Two' === $import_file_name ||
+				'Demo Three' === $import_file_name
+			) {
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'menu-1' => $primary_menu->term_id, 
-			     	)
-			    );
-	    	} else if( $import_file_name == 'Demo Four' ) {
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
 
-	    		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'menu-1' => $primary_menu->term_id,
+					)
+				);
+			} elseif ( 'Demo Four' === $import_file_name ) {
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'menu-1' => $primary_menu->term_id, 
-			     	)
-			    );
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
 
-	    		$american_cuisine_category	= get_term_by( 'slug', 'american-cuisine', 'category' );
-			    $breakfast_category	= get_term_by( 'slug', 'breakfast', 'category' );
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'menu-1' => $primary_menu->term_id,
+					)
+				);
 
-			   	$banner_cats = array( $american_cuisine_category->term_id, $breakfast_category->term_id );
+				$american_cuisine_category = get_term_by( 'slug', 'american-cuisine', 'category' );
+				$breakfast_category        = get_term_by( 'slug', 'breakfast', 'category' );
 
-			   	set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
-	    	} else if( $import_file_name == 'Demo Five' ) {
+				$banner_cats = array( $american_cuisine_category->term_id, $breakfast_category->term_id );
 
-	    		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-	    		$header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
+				set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
+			} elseif ( 'Demo Five' === $import_file_name ) {
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'menu-1' => $primary_menu->term_id, 
-			     		'menu-2' => $header_menu->term_id,
-			     	)
-			    );
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+				$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
 
-	    		$diy_category	= get_term_by( 'slug', 'diy', 'category' );
-			    $fashion_category	= get_term_by( 'slug', 'fashion', 'category' );
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'menu-1' => $primary_menu->term_id,
+						'menu-2' => $header_menu->term_id,
+					)
+				);
 
-			   	$banner_cats = array( $diy_category->term_id, $fashion_category->term_id );
+				$diy_category     = get_term_by( 'slug', 'diy', 'category' );
+				$fashion_category = get_term_by( 'slug', 'fashion', 'category' );
 
-			   	set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
-	    	} else if( $import_file_name == 'Demo Six' ) {
+				$banner_cats = array( $diy_category->term_id, $fashion_category->term_id );
 
-	    		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-	    		$header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
+				set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
+			} elseif ( 'Demo Six' === $import_file_name ) {
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'menu-1' => $primary_menu->term_id, 
-			     		'menu-2' => $header_menu->term_id,
-			     	)
-			    );
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+				$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
 
-	    		$basketball_category	= get_term_by( 'slug', 'basketball', 'category' );
-			    $football_category	= get_term_by( 'slug', 'football', 'category' );
-			    $golf_category	= get_term_by( 'slug', 'golf', 'category' );
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'menu-1' => $primary_menu->term_id,
+						'menu-2' => $header_menu->term_id,
+					)
+				);
 
-			   	$banner_cats = array( $basketball_category->term_id, $football_category->term_id, $golf_category->term_id );
+				$basketball_category = get_term_by( 'slug', 'basketball', 'category' );
+				$football_category   = get_term_by( 'slug', 'football', 'category' );
+				$golf_category       = get_term_by( 'slug', 'golf', 'category' );
 
-			   	set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
-	    	} else if( $import_file_name == 'Demo Seven' ) {
+				$banner_cats = array( $basketball_category->term_id, $football_category->term_id, $golf_category->term_id );
 
-	    		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
+				set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
+			} elseif ( 'Demo Seven' === $import_file_name ) {
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'menu-1' => $primary_menu->term_id, 
-			     	)
-			    );
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
 
-	    		$diy_category	= get_term_by( 'slug', 'diy', 'category' );
-			    $photography_category	= get_term_by( 'slug', 'photography', 'category' );
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'menu-1' => $primary_menu->term_id,
+					)
+				);
 
-			   	$banner_cats = array( $diy_category->term_id, $photography_category->term_id );
+				$diy_category         = get_term_by( 'slug', 'diy', 'category' );
+				$photography_category = get_term_by( 'slug', 'photography', 'category' );
 
-			   	set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
-	    	} else {
+				$banner_cats = array( $diy_category->term_id, $photography_category->term_id );
 
-	    		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
+				set_theme_mod( 'cream_blog_pro_banner_categories', $banner_cats );
+			} else {
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'menu-1' => $primary_menu->term_id, 
-			     	)
-			    );
-	    	}
-	    }    
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
 
-		update_option( 'themebeez_themes', $installed_demos );
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'menu-1' => $primary_menu->term_id,
+					)
+				);
+			}
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-blog.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-blog.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Cream_Blog extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/cream-blog/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -42,49 +42,49 @@ class TT_Theme_Demo_Cream_Blog extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $header_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
 
-	    $import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $header_menu->term_id,
+			)
+		);
 
-	    if( !empty( $import_file_name ) ) {
+		$import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
 
-	    	if( $import_file_name === 'Demo One' ) {
+		if ( ! empty( $import_file_name ) ) {
 
-	    		$diy_category		= get_term_by( 'slug', 'diy', 'category' );
-			    $modelling_category		= get_term_by( 'slug', 'modelling', 'category' );
+			if ( 'Demo One' === $import_file_name ) {
 
-			   	$banner_cats = array( $diy_category->term_id, $modelling_category->term_id );
+				$diy_category       = get_term_by( 'slug', 'diy', 'category' );
+				$modelling_category = get_term_by( 'slug', 'modelling', 'category' );
 
-			   	set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
+				$banner_cats = array( $diy_category->term_id, $modelling_category->term_id );
 
-	    	} else if( $import_file_name === 'Demo Two' ) {
+				set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
 
-	    		$american_cuisine_category		= get_term_by( 'slug', 'american-cuisine', 'category' );
-			    $breakfast_category		= get_term_by( 'slug', 'breakfase', 'category' );
+			} elseif ( 'Demo Two' === $import_file_name ) {
 
-			   	$banner_cats = array( $american_cuisine_category->term_id, $breakfast_category->term_id );
+				$american_cuisine_category = get_term_by( 'slug', 'american-cuisine', 'category' );
+				$breakfast_category        = get_term_by( 'slug', 'breakfase', 'category' );
 
-			   	set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
-	    	} else {
+				$banner_cats = array( $american_cuisine_category->term_id, $breakfast_category->term_id );
 
-	    		$fashion_category		= get_term_by( 'slug', 'fashion', 'category' );
-			    $lifestyle_category		= get_term_by( 'slug', 'lifestyle', 'category' );
+				set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
+			} else {
 
-			   	$banner_cats = array( $fashion_category->term_id, $lifestyle_category->term_id );
+				$fashion_category   = get_term_by( 'slug', 'fashion', 'category' );
+				$lifestyle_category = get_term_by( 'slug', 'lifestyle', 'category' );
 
-			   	set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
-	    	}
-	    }    
+				$banner_cats = array( $fashion_category->term_id, $lifestyle_category->term_id );
 
-		update_option( 'themebeez_themes', $installed_demos );
+				set_theme_mod( 'cream_blog_banner_categories', $banner_cats );
+			}
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-magazine-pro.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-magazine-pro.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Cream_Magazine_Pro extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/cream-magazine-pro/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -50,7 +50,7 @@ class TT_Theme_Demo_Cream_Magazine_Pro extends TT_Theme_Demo {
 				'import_customizer_file_url' => $server_url . 'demo-five/customizer.dat',
 				'import_preview_image_url'   => $server_url . 'demo-five/screenshot.png',
 				'demo_url'                   => 'https://themebeez.com/demos/?theme=cream-magazine-pro-v',
-			)
+			),
 		);
 
 		return $demo_urls;
@@ -58,27 +58,41 @@ class TT_Theme_Demo_Cream_Magazine_Pro extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
-	    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $header_menu->term_id,
-	     		'menu-3' => $footer_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
+		$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-	    // Assign front page and posts page (blog page).
-		$front_page_id = get_page_by_title( 'Home' );
-		$blog_page_id  = get_page_by_title( 'Blog' );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $header_menu->term_id,
+				'menu-3' => $footer_menu->term_id,
+			)
+		);
 
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $front_page_id->ID );
-		update_option( 'page_for_posts', $blog_page_id->ID );
 
-		update_option( 'themebeez_themes', $installed_demos );
+		$front_page = new WP_Query( array( 'pagename' => 'home' ) );
+
+		if ( $front_page->have_posts() ) {
+			while ( $front_page->have_posts() ) {
+				$front_page->the_post();
+				update_option( 'page_on_front', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
+
+		$blog_page = new WP_Query( array( 'pagename' => 'blog' ) );
+
+		if ( $blog_page->have_posts() ) {
+			while ( $blog_page->have_posts() ) {
+				$blog_page->the_post();
+				update_option( 'page_for_posts', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-magazine.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-cream-magazine.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Cream_Magazine extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/cream-magazine/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -26,7 +26,7 @@ class TT_Theme_Demo_Cream_Magazine extends TT_Theme_Demo {
 				'import_customizer_file_url' => $server_url . 'demo-two/customizer.dat',
 				'import_preview_image_url'   => $server_url . 'demo-two/screenshot.png',
 				'demo_url'                   => 'https://themebeez.com/demos/?theme=cream-magazine-ii',
-			)
+			),
 		);
 
 		return $demo_urls;
@@ -34,27 +34,41 @@ class TT_Theme_Demo_Cream_Magazine extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
-	    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $header_menu->term_id,
-	     		'menu-3' => $footer_menu->term_id,
-	     	)
-	    );   
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
+		$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-	    // Assign front page and posts page (blog page).
-		$front_page_id = get_page_by_title( 'Home' );
-		$blog_page_id  = get_page_by_title( 'Blog' );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $header_menu->term_id,
+				'menu-3' => $footer_menu->term_id,
+			)
+		);
 
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $front_page_id->ID );
-		update_option( 'page_for_posts', $blog_page_id->ID );
-		
-		update_option( 'themebeez_themes', $installed_demos );
+
+		$front_page = new WP_Query( array( 'pagename' => 'home' ) );
+
+		if ( $front_page->have_posts() ) {
+			while ( $front_page->have_posts() ) {
+				$front_page->the_post();
+				update_option( 'page_on_front', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
+
+		$blog_page = new WP_Query( array( 'pagename' => 'blog' ) );
+
+		if ( $blog_page->have_posts() ) {
+			while ( $blog_page->have_posts() ) {
+				$blog_page->the_post();
+				update_option( 'page_for_posts', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-fascinate-pro.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-fascinate-pro.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Fascinate_Pro extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/fascinate-pro/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -50,17 +50,17 @@ class TT_Theme_Demo_Fascinate_Pro extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $header_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
 
-		update_option( 'themebeez_themes', $installed_demos );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $header_menu->term_id,
+			)
+		);
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-fascinate.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-fascinate.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Fascinate extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/fascinate/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -18,7 +18,7 @@ class TT_Theme_Demo_Fascinate extends TT_Theme_Demo {
 				'import_customizer_file_url' => $server_url . 'demo-one/customizer.dat',
 				'import_preview_image_url'   => $server_url . 'demo-one/screenshot.jpg',
 				'demo_url'                   => 'https://demo.themebeez.com/demos-2/fascinate/',
-			)
+			),
 		);
 
 		return $demo_urls;
@@ -26,17 +26,17 @@ class TT_Theme_Demo_Fascinate extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Top Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $header_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Top Menu', 'nav_menu' );
 
-		update_option( 'themebeez_themes', $installed_demos );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $header_menu->term_id,
+			)
+		);
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-orchid-store.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-orchid-store.php
@@ -8,7 +8,7 @@ class TT_Theme_Demo_Orchid_Store extends TT_Theme_Demo {
 
 	public static function import_files() {
 
-		if( class_exists( 'Orchid_Store_Pro_Demo_Import' ) ) {
+		if ( class_exists( 'Orchid_Store_Pro_Demo_Import' ) ) {
 
 			$demo_class = new Orchid_Store_Pro_Demo_Import();
 
@@ -17,7 +17,7 @@ class TT_Theme_Demo_Orchid_Store extends TT_Theme_Demo {
 
 			$server_url = 'https://themebeez.com/demo-contents/orchid-store/';
 
-			$demo_urls  = array(
+			$demo_urls = array(
 				array(
 					'import_file_name'           => esc_html__( 'Default Demo', 'themebeez-toolkit' ),
 					'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -50,25 +50,51 @@ class TT_Theme_Demo_Orchid_Store extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Primary menu', 'nav_menu'); 
-		$secondary_menu 	= get_term_by('name', 'Secondary menu', 'nav_menu'); 
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id,
-	     		'menu-2' => $secondary_menu->term_id,
-	     	)
-	    );
+		$primary_menu   = get_term_by( 'name', 'Primary menu', 'nav_menu' );
+		$secondary_menu = get_term_by( 'name', 'Secondary menu', 'nav_menu' );
 
-	    // Assign front page and posts page (blog page).
-		$front_page_id = get_page_by_title( 'Homepage' );
-		$blog_page_id  = get_page_by_title( 'Blog' );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $secondary_menu->term_id,
+			)
+		);
+
+		$import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
+
+		$front_page_query_arg = array();
+
+		if ( ! empty( $import_file_name ) ) {
+			if ( 'Elementor Demo' === $import_file_name || 'RTL Demo' === $import_file_name ) {
+				$front_page_query_arg['pagename'] = 'elementor-front-page';
+			} else {
+				$front_page_query_arg['pagename'] = 'homepage';
+			}
+		}
+
+		$front_page = new WP_Query( $front_page_query_arg );
+
+		if ( $front_page->have_posts() ) {
+			while ( $front_page->have_posts() ) {
+				$front_page->the_post();
+				update_option( 'page_on_front', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
+
+		$blog_page = new WP_Query( array( 'pagename' => 'blog' ) );
+
+		if ( $blog_page->have_posts() ) {
+			while ( $blog_page->have_posts() ) {
+				$blog_page->the_post();
+				update_option( 'page_for_posts', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
 
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $front_page_id->ID );
-		update_option( 'page_for_posts', $blog_page_id->ID );
-
-		update_option( 'themebeez_themes', $installed_demos );
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-royale-news-lite.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-royale-news-lite.php
@@ -26,86 +26,98 @@ class TT_Theme_Demo_Royale_News_Lite extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-	    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'primary' => $primary_menu->term_id,
-	     		'footer' => $footer_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-	    $beauty_category = get_term_by( 'slug', 'beauty', 'category' );
-	    $beauty_category_id = $beauty_category->term_id;
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'primary' => $primary_menu->term_id,
+				'footer'  => $footer_menu->term_id,
+			)
+		);
 
-	    $lifestyle_category = get_term_by( 'slug', 'lifestyle', 'category' );
-	    $lifestyle_category_id = $lifestyle_category->term_id;
+		$beauty_category    = get_term_by( 'slug', 'beauty', 'category' );
+		$beauty_category_id = $beauty_category->term_id;
 
-	    $travel_category = get_term_by( 'slug', 'travel', 'category' );
-	    $travel_category_id = $travel_category->term_id;
+		$lifestyle_category    = get_term_by( 'slug', 'lifestyle', 'category' );
+		$lifestyle_category_id = $lifestyle_category->term_id;
 
-	    $events_category = get_term_by( 'slug', 'events', 'category' );
-	    $events_category_id = $events_category->term_id;
+		$travel_category    = get_term_by( 'slug', 'travel', 'category' );
+		$travel_category_id = $travel_category->term_id;
 
-	    $fashion_category = get_term_by( 'slug', 'fashion', 'category' );
-	    $fashion_category_id = $fashion_category->term_id;
+		$events_category    = get_term_by( 'slug', 'events', 'category' );
+		$events_category_id = $events_category->term_id;
 
-	    $events_category = get_term_by( 'slug', 'fashion', 'category' );
-	    $events_category_id = $events_category->term_id;
+		$fashion_category    = get_term_by( 'slug', 'fashion', 'category' );
+		$fashion_category_id = $fashion_category->term_id;
 
-	    $photography_category = get_term_by( 'slug', 'photography', 'category' );
-	    $photography_category_id = $photography_category->term_id;
+		$events_category    = get_term_by( 'slug', 'fashion', 'category' );
+		$events_category_id = $events_category->term_id;
 
+		$photography_category    = get_term_by( 'slug', 'photography', 'category' );
+		$photography_category_id = $photography_category->term_id;
 
-	    $banner_widget = get_option('widget_royale-news-main-highlight-two');
+		$banner_widget = get_option( 'widget_royale-news-main-highlight-two' );
 
-	    $banner_widget[1]['cat_1'] = absint( $fashion_category_id );
-	    $banner_widget[1]['cat_2'] = absint( $beauty_category_id );
-	    $banner_widget[1]['cat_3'] = absint( $lifestyle_category_id );
+		$banner_widget[1]['cat_1'] = absint( $fashion_category_id );
+		$banner_widget[1]['cat_2'] = absint( $beauty_category_id );
+		$banner_widget[1]['cat_3'] = absint( $lifestyle_category_id );
 
-	    update_option( 'widget_royale-news-main-highlight-two', $banner_widget );
+		update_option( 'widget_royale-news-main-highlight-two', $banner_widget );
 
+		$first_widget = get_option( 'widget_royale-news-news-layout-widget-one' );
 
-	    $first_widget = get_option( 'widget_royale-news-news-layout-widget-one' );
+		$first_widget[1]['cat'] = absint( $travel_category_id );
 
-	    $first_widget[1]['cat'] = absint( $travel_category_id );
+		update_option( 'widget_royale-news-news-layout-widget-one', $first_widget );
 
-	    update_option( 'widget_royale-news-news-layout-widget-one', $first_widget );
+		$second_widget = get_option( 'widget_royale-news-news-layout-widget-two' );
 
+		$second_widget[1]['cat'] = absint( $events_category_id );
 
-	    $second_widget = get_option( 'widget_royale-news-news-layout-widget-two' );
+		update_option( 'widget_royale-news-news-layout-widget-two', $second_widget );
 
-	    $second_widget[1]['cat'] = absint( $events_category_id );
+		$third_widget = get_option( 'widget_royale-news-bottom-news-widget-one' );
 
-	    update_option( 'widget_royale-news-news-layout-widget-two', $second_widget );
+		$third_widget[1]['cat'] = array( absint( $lifestyle_category_id ) ); 
 
-	    $third_widget = get_option( 'widget_royale-news-bottom-news-widget-one' );
+		update_option( 'widget_royale-news-bottom-news-widget-one', $third_widget );
 
-	    $third_widget[1]['cat'] = array( absint( $lifestyle_category_id ) ); 
+		$fourth_widget = get_option( 'widget_royale-news-bottom-news-widget-two' );
 
-	    update_option( 'widget_royale-news-bottom-news-widget-one', $third_widget );
+		$fourth_widget[1]['cat'] = array( absint( $fashion_category_id ) );
 
-	    $fourth_widget = get_option( 'widget_royale-news-bottom-news-widget-two' );
+		update_option( 'widget_royale-news-bottom-news-widget-two', $fourth_widget );
 
-	    $fourth_widget[1]['cat'] = array( absint( $fashion_category_id ) );
+		$fifth_widget = get_option( 'widget_royale-news-sidebar-widget-one' );
 
-	    update_option( 'widget_royale-news-bottom-news-widget-two', $fourth_widget );
+		$fifth_widget[1]['cat'] = array( absint( $photography_category_id ) );
 
-	    $fifth_widget = get_option( 'widget_royale-news-sidebar-widget-one' );
-
-	    $fifth_widget[1]['cat'] = array( absint( $photography_category_id ) );
-
-	    update_option( 'widget_royale-news-sidebar-widget-one', $fifth_widget );
-
-		// Assign front page and posts page (blog page).
-		$front_page_id = get_page_by_title( 'Home' );
-		$blog_page_id  = get_page_by_title( 'Blog' );
+		update_option( 'widget_royale-news-sidebar-widget-one', $fifth_widget );
 
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $front_page_id->ID );
-		update_option( 'page_for_posts', $blog_page_id->ID );
-		update_option( 'themebeez_themes', $installed_demos );
+
+		$front_page = new WP_Query( array( 'pagename' => 'home' ) );
+
+		if ( $front_page->have_posts() ) {
+			while ( $front_page->have_posts() ) {
+				$front_page->the_post();
+				update_option( 'page_on_front', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
+
+		$blog_page = new WP_Query( array( 'pagename' => 'blog' ) );
+
+		if ( $blog_page->have_posts() ) {
+			while ( $blog_page->have_posts() ) {
+				$blog_page->the_post();
+				update_option( 'page_for_posts', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-royale-news-pro.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-royale-news-pro.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Royale_News_Pro extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/royale-news-pro/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => __( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -42,226 +42,241 @@ class TT_Theme_Demo_Royale_News_Pro extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-	    $import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
+		update_option( 'widget_block', array() );
 
-	    if( !empty( $import_file_name ) ) {
+		$import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
 
-	    	if( $import_file_name == 'Demo One' ) {
+		if ( ! empty( $import_file_name ) ) {
 
-	    		$fashion_category = get_term_by( 'slug', 'fashion', 'category' );
-	    		$fashion_category_id = $fashion_category->term_id;
+			if ( 'Demo One' === $import_file_name ) {
 
-	    		$business_category = get_term_by( 'slug', 'business', 'category' );
-	    		$business_category_id = $business_category->term_id;
+				$fashion_category    = get_term_by( 'slug', 'fashion', 'category' );
+				$fashion_category_id = $fashion_category->term_id;
 
-	    		$sports_category = get_term_by( 'slug', 'sports', 'category' );
-	    		$sports_category_id = $sports_category->term_id;
+				$business_category    = get_term_by( 'slug', 'business', 'category' );
+				$business_category_id = $business_category->term_id;
 
-	    		$events_category = get_term_by( 'slug', 'events', 'category' );
-	    		$events_category_id = $events_category->term_id;
+				$sports_category    = get_term_by( 'slug', 'sports', 'category' );
+				$sports_category_id = $sports_category->term_id;
 
-	    		$politics_category = get_term_by( 'slug', 'politics', 'category' );
-	    		$politics_category_id = $politics_category->term_id;
+				$events_category    = get_term_by( 'slug', 'events', 'category' );
+				$events_category_id = $events_category->term_id;
 
-	    		$technology_category = get_term_by( 'slug', 'technology', 'category' );
-	    		$technology_category_id = $technology_category->term_id;
+				$politics_category    = get_term_by( 'slug', 'politics', 'category' );
+				$politics_category_id = $politics_category->term_id;
 
-	    		$wildlife_category = get_term_by( 'slug', 'wildlife', 'category' );
-	    		$wildlife_category_id = $wildlife_category->term_id;
+				$technology_category    = get_term_by( 'slug', 'technology', 'category' );
+				$technology_category_id = $technology_category->term_id;
 
-	    		$sidebar_slider_widget = get_option('widget_sidebar-widget-four');
-	    		$sidebar_slider_widget[1]['cat'] = absint( $events_category_id );
-	    		update_option( 'widget_sidebar-widget-four', $sidebar_slider_widget );
+				$wildlife_category    = get_term_by( 'slug', 'wildlife', 'category' );
+				$wildlife_category_id = $wildlife_category->term_id;
 
-	    		$main_highlight = get_option('widget_royale-news-pro-main-highlight-two');
-			    $main_highlight[1]['cat_1'] = absint( $fashion_category_id );
-			    $main_highlight[1]['cat_2'] = absint( $business_category_id );
-			    $main_highlight[1]['cat_3'] = absint( $politics_category_id );
-			    update_option( 'widget_royale-news-pro-main-highlight-two', $main_highlight );
+				$sidebar_slider_widget           = get_option( 'widget_sidebar-widget-four' );
+				$sidebar_slider_widget[1]['cat'] = absint( $events_category_id );
+				update_option( 'widget_sidebar-widget-four', $sidebar_slider_widget );
 
-			    $slider_highlight = get_option( 'widget_royale-news-pro-slider-highlight_two' );
-			    $slider_highlight[1]['cat'] = absint( $events_category_id );
-			    update_option( 'widget_royale-news-pro-slider-highlight_two', $slider_highlight );
+				$main_highlight             = get_option( 'widget_royale-news-pro-main-highlight-two' );
+				$main_highlight[1]['cat_1'] = absint( $fashion_category_id );
+				$main_highlight[1]['cat_2'] = absint( $business_category_id );
+				$main_highlight[1]['cat_3'] = absint( $politics_category_id );
+				update_option( 'widget_royale-news-pro-main-highlight-two', $main_highlight );
 
-			    $layout_one_widget = get_option( 'widget_news-layout-widget-one' );
-			    $layout_one_widget[1]['cat'] = absint( $politics_category_id );
-			    update_option( 'widget_news-layout-widget-one', $layout_one_widget );
+				$slider_highlight           = get_option( 'widget_royale-news-pro-slider-highlight_two' );
+				$slider_highlight[1]['cat'] = absint( $events_category_id );
+				update_option( 'widget_royale-news-pro-slider-highlight_two', $slider_highlight );
 
-			    $layout_two_widget = get_option( 'widget_news-layout-widget-two' );
-			    $layout_two_widget[1]['cat'] = absint( $business_category_id );
-			    $layout_two_widget[2]['cat'] = absint( $sports_category_id );
-			    update_option( 'widget_news-layout-widget-two', $layout_two_widget );
+				$layout_one_widget           = get_option( 'widget_news-layout-widget-one' );
+				$layout_one_widget[1]['cat'] = absint( $politics_category_id );
+				update_option( 'widget_news-layout-widget-one', $layout_one_widget );
 
-			    $layout_three_widget = get_option( 'widget_news-layout-widget-three' );
-			    $layout_three_widget[1]['cat'] = absint( $technology_category_id );
-			    update_option( 'widget_news-layout-widget-three', $layout_three_widget );
+				$layout_two_widget           = get_option( 'widget_news-layout-widget-two' );
+				$layout_two_widget[1]['cat'] = absint( $business_category_id );
+				$layout_two_widget[2]['cat'] = absint( $sports_category_id );
+				update_option( 'widget_news-layout-widget-two', $layout_two_widget );
 
-			    $layout_four_widget = get_option( 'widget_news-layout-widget-four' );
-			    $layout_four_widget[1]['cat'] = absint( $fashion_category_id );
-			    update_option( 'widget_news-layout-widget-four', $layout_four_widget );
+				$layout_three_widget           = get_option( 'widget_news-layout-widget-three' );
+				$layout_three_widget[1]['cat'] = absint( $technology_category_id );
+				update_option( 'widget_news-layout-widget-three', $layout_three_widget );
 
-			    $layout_five_widget = get_option( 'widget_royale-news-pro-bottom-news-widget-two' );
-			    $layout_five_widget[1]['cat'][0] = $fashion_category_id;
-			    $layout_five_widget[1]['cat'][1] = $wildlife_category_id;
-			    update_option( 'widget_royale-news-pro-bottom-news-widget-two', $layout_five_widget );
+				$layout_four_widget           = get_option( 'widget_news-layout-widget-four' );
+				$layout_four_widget[1]['cat'] = absint( $fashion_category_id );
+				update_option( 'widget_news-layout-widget-four', $layout_four_widget );
 
-			    $layout_six_widget = get_option( 'widget_royale-news-pro-bottom-news-widget-one' );
-			    $layout_six_widget[1]['cat'][0] = $business_category_id;
-			    $layout_six_widget[1]['cat'][1] = $events_category_id;
-			    $layout_six_widget[1]['cat'][2] = $food_category_id;
-			    update_option( 'widget_royale-news-pro-bottom-news-widget-one', $layout_six_widget );
+				$layout_five_widget              = get_option( 'widget_royale-news-pro-bottom-news-widget-two' );
+				$layout_five_widget[1]['cat'][0] = $fashion_category_id;
+				$layout_five_widget[1]['cat'][1] = $wildlife_category_id;
+				update_option( 'widget_royale-news-pro-bottom-news-widget-two', $layout_five_widget );
 
-			    $primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-				$social_menu 	= get_term_by('name', 'Social Menu', 'nav_menu');  
-			    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+				$layout_six_widget              = get_option( 'widget_royale-news-pro-bottom-news-widget-one' );
+				$layout_six_widget[1]['cat'][0] = $business_category_id;
+				$layout_six_widget[1]['cat'][1] = $events_category_id;
+				$layout_six_widget[1]['cat'][2] = $food_category_id;
+				update_option( 'widget_royale-news-pro-bottom-news-widget-one', $layout_six_widget );
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'primary' => $primary_menu->term_id, 
-			     		'social' => $social_menu->term_id,
-			     		'footer' => $footer_menu->term_id,
-			     	)
-			    );
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+				$social_menu  = get_term_by( 'name', 'Social Menu', 'nav_menu' );
+				$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-	    	} else if( $import_file_name == 'Demo Two' ) {
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'primary' => $primary_menu->term_id,
+						'social'  => $social_menu->term_id,
+						'footer'  => $footer_menu->term_id,
+					)
+				);
 
-	    		$fashion_category = get_term_by( 'slug', 'fashion', 'category' );
-	    		$fashion_category_id = $fashion_category->term_id;
+			} elseif ( 'Demo Two' === $import_file_name ) {
 
-	    		$business_category = get_term_by( 'slug', 'business', 'category' );
-	    		$business_category_id = $business_category->term_id;
+				$fashion_category    = get_term_by( 'slug', 'fashion', 'category' );
+				$fashion_category_id = $fashion_category->term_id;
 
-	    		$war_category = get_term_by( 'slug', 'war', 'category' );
-	    		$war_category_id = $war_category->term_id;
+				$business_category    = get_term_by( 'slug', 'business', 'category' );
+				$business_category_id = $business_category->term_id;
 
-	    		$sports_category = get_term_by( 'slug', 'sports', 'category' );
-	    		$sports_category_id = $sports_category->term_id;
+				$war_category    = get_term_by( 'slug', 'war', 'category' );
+				$war_category_id = $war_category->term_id;
 
-	    		$politics_category = get_term_by( 'slug', 'politics', 'category' );
-	    		$politics_category_id = $politics_category->term_id;
+				$sports_category    = get_term_by( 'slug', 'sports', 'category' );
+				$sports_category_id = $sports_category->term_id;
 
-	    		$technology_category = get_term_by( 'slug', 'technology', 'category' );
-	    		$technology_category_id = $technology_category->term_id;
+				$politics_category    = get_term_by( 'slug', 'politics', 'category' );
+				$politics_category_id = $politics_category->term_id;
 
-	    		$main_highlight = get_option('widget_royale-news-pro-slider-highlight_one');
-			    $main_highlight[1]['cat'] = absint( $politics_category_id );
-			    update_option( 'widget_royale-news-pro-slider-highlight_one', $main_highlight );
+				$technology_category    = get_term_by( 'slug', 'technology', 'category' );
+				$technology_category_id = $technology_category->term_id;
 
-			    $slider_highlight = get_option( 'widget_royale-news-pro-slider-highlight_two' );
-			    $slider_highlight[1]['cat'] = absint( $war_category_id );
-			    update_option( 'widget_royale-news-pro-slider-highlight_two', $slider_highlight );
+				$main_highlight           = get_option( 'widget_royale-news-pro-slider-highlight_one' );
+				$main_highlight[1]['cat'] = absint( $politics_category_id );
+				update_option( 'widget_royale-news-pro-slider-highlight_one', $main_highlight );
 
-			    $layout_two_widget = get_option( 'widget_news-layout-widget-two' );
-			    $layout_two_widget[1]['cat'] = absint( $politics_category_id );
-			    $layout_two_widget[2]['cat'] = absint( $sports_category_id );
-			    update_option( 'widget_news-layout-widget-two', $layout_two_widget );
+				$slider_highlight           = get_option( 'widget_royale-news-pro-slider-highlight_two' );
+				$slider_highlight[1]['cat'] = absint( $war_category_id );
+				update_option( 'widget_royale-news-pro-slider-highlight_two', $slider_highlight );
 
-			    $layout_three_widget = get_option( 'widget_news-layout-widget-three' );
-			    $layout_three_widget[1]['cat'] = absint( $fashion_category_id );
-			    update_option( 'widget_news-layout-widget-three', $layout_three_widget );
+				$layout_two_widget           = get_option( 'widget_news-layout-widget-two' );
+				$layout_two_widget[1]['cat'] = absint( $politics_category_id );
+				$layout_two_widget[2]['cat'] = absint( $sports_category_id );
+				update_option( 'widget_news-layout-widget-two', $layout_two_widget );
 
-			    $layout_four_widget = get_option( 'widget_news-layout-widget-four' );
-			    $layout_four_widget[1]['cat'] = absint( $business_category_id );
-			    update_option( 'widget_news-layout-widget-four', $layout_four_widget );
+				$layout_three_widget           = get_option( 'widget_news-layout-widget-three' );
+				$layout_three_widget[1]['cat'] = absint( $fashion_category_id );
+				update_option( 'widget_news-layout-widget-three', $layout_three_widget );
 
-			    $layout_five_widget = get_option( 'widget_royale-news-pro-bottom-news-widget-two' );
-			    $layout_five_widget[1]['cat'][0] = $fashion_category_id;
-			    $layout_five_widget[1]['cat'][1] = $politics_category_id;
-			    $layout_five_widget[1]['cat'][2] = $war_category_id;
-			    update_option( 'widget_royale-news-pro-bottom-news-widget-two', $layout_five_widget );
+				$layout_four_widget           = get_option( 'widget_news-layout-widget-four' );
+				$layout_four_widget[1]['cat'] = absint( $business_category_id );
+				update_option( 'widget_news-layout-widget-four', $layout_four_widget );
 
-			    $layout_six_widget = get_option( 'widget_royale-news-pro-bottom-news-widget-one' );
-			    $layout_six_widget[1]['cat'][0] = $technology_category_id;
-			    update_option( 'widget_royale-news-pro-bottom-news-widget-one', $layout_six_widget );
+				$layout_five_widget              = get_option( 'widget_royale-news-pro-bottom-news-widget-two' );
+				$layout_five_widget[1]['cat'][0] = $fashion_category_id;
+				$layout_five_widget[1]['cat'][1] = $politics_category_id;
+				$layout_five_widget[1]['cat'][2] = $war_category_id;
+				update_option( 'widget_royale-news-pro-bottom-news-widget-two', $layout_five_widget );
 
-			    $primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-			    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+				$layout_six_widget              = get_option( 'widget_royale-news-pro-bottom-news-widget-one' );
+				$layout_six_widget[1]['cat'][0] = $technology_category_id;
+				update_option( 'widget_royale-news-pro-bottom-news-widget-one', $layout_six_widget );
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'primary' => $primary_menu->term_id, 
-			     		'footer' => $footer_menu->term_id,
-			     	)
-			    );
-	    	} else {
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+				$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-	    		$fashion_category = get_term_by( 'slug', 'fashion', 'category' );
-	    		$fashion_category_id = $fashion_category->term_id;
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'primary' => $primary_menu->term_id,
+						'footer'  => $footer_menu->term_id,
+					)
+				);
+			} else {
 
-	    		$gossip_category = get_term_by( 'slug', 'gossip', 'category' );
-	    		$gossip_category_id = $gossip_category->term_id;
+				$fashion_category    = get_term_by( 'slug', 'fashion', 'category' );
+				$fashion_category_id = $fashion_category->term_id;
 
-	    		$beauty_category = get_term_by( 'slug', 'beauty', 'category' );
-	    		$beauty_category_id = $beauty_category->term_id;
+				$gossip_category    = get_term_by( 'slug', 'gossip', 'category' );
+				$gossip_category_id = $gossip_category->term_id;
 
-	    		$lifestyle_category = get_term_by( 'slug', 'lifestyle', 'category' );
-	    		$lifestyle_category_id = $lifestyle_category->term_id;
+				$beauty_category    = get_term_by( 'slug', 'beauty', 'category' );
+				$beauty_category_id = $beauty_category->term_id;
 
-	    		$photography_category = get_term_by( 'slug', 'photography', 'category' );
-	    		$photography_category_id = $photography_category->term_id;
+				$lifestyle_category    = get_term_by( 'slug', 'lifestyle', 'category' );
+				$lifestyle_category_id = $lifestyle_category->term_id;
 
-	    		$food_drink_category = get_term_by( 'slug', 'food-drink', 'category' );
-	    		$food_drink_category_id = $food_drink_category->term_id;
+				$photography_category    = get_term_by( 'slug', 'photography', 'category' );
+				$photography_category_id = $photography_category->term_id;
 
-	    		$travel_living_category = get_term_by( 'slug', 'travel-living', 'category' );
-	    		$travel_living_category_id = $travel_living_category->term_id;
+				$food_drink_category    = get_term_by( 'slug', 'food-drink', 'category' );
+				$food_drink_category_id = $food_drink_category->term_id;
 
-	    		$sidebar_slider_widget = get_option('widget_sidebar-widget-four');
-	    		$sidebar_slider_widget[1]['cat'] = absint( $gossip_category_id );
-	    		update_option( 'widget_sidebar-widget-four', $sidebar_slider_widget );
+				$travel_living_category    = get_term_by( 'slug', 'travel-living', 'category' );
+				$travel_living_category_id = $travel_living_category->term_id;
 
-	    		$main_highlight = get_option('widget_royale-news-pro-main-highlight-two');
-			    $main_highlight[1]['cat_1'] = absint( $fashion_category_id );
-			    $main_highlight[1]['cat_2'] = absint( $beauty_category_id );
-			    $main_highlight[1]['cat_3'] = absint( $lifestyle_category_id );
-			    update_option( 'widget_royale-news-pro-main-highlight-two', $main_highlight );
+				$sidebar_slider_widget           = get_option( 'widget_sidebar-widget-four' );
+				$sidebar_slider_widget[1]['cat'] = absint( $gossip_category_id );
+				update_option( 'widget_sidebar-widget-four', $sidebar_slider_widget );
 
-			    $slider_highlight = get_option( 'widget_royale-news-pro-slider-highlight_two' );
-			    $slider_highlight[1]['cat'] = absint( $lifestyle_category_id );
-			    update_option( 'widget_royale-news-pro-slider-highlight_two', $slider_highlight );
+				$main_highlight             = get_option( 'widget_royale-news-pro-main-highlight-two' );
+				$main_highlight[1]['cat_1'] = absint( $fashion_category_id );
+				$main_highlight[1]['cat_2'] = absint( $beauty_category_id );
+				$main_highlight[1]['cat_3'] = absint( $lifestyle_category_id );
+				update_option( 'widget_royale-news-pro-main-highlight-two', $main_highlight );
 
-	    		$layout_one_widget = get_option( 'widget_news-layout-widget-one' );
-			    $layout_one_widget[1]['cat'] = absint( $food_drink_category_id );
-			    update_option( 'widget_news-layout-widget-one', $layout_one_widget );
+				$slider_highlight           = get_option( 'widget_royale-news-pro-slider-highlight_two' );
+				$slider_highlight[1]['cat'] = absint( $lifestyle_category_id );
+				update_option( 'widget_royale-news-pro-slider-highlight_two', $slider_highlight );
 
-	    		$layout_two_widget = get_option( 'widget_news-layout-widget-two' );
-			    $layout_two_widget[1]['cat'] = absint( $travel_living_category_id );
-			    update_option( 'widget_news-layout-widget-two', $layout_two_widget );
+				$layout_one_widget           = get_option( 'widget_news-layout-widget-one' );
+				$layout_one_widget[1]['cat'] = absint( $food_drink_category_id );
+				update_option( 'widget_news-layout-widget-one', $layout_one_widget );
 
-			    $layout_three_widget = get_option( 'widget_news-layout-widget-three' );
-			    $layout_three_widget[1]['cat'] = absint( $photography_category_id );
-			    update_option( 'widget_news-layout-widget-three', $layout_three_widget );
+				$layout_two_widget           = get_option( 'widget_news-layout-widget-two' );
+				$layout_two_widget[1]['cat'] = absint( $travel_living_category_id );
+				update_option( 'widget_news-layout-widget-two', $layout_two_widget );
 
-	    		$bottom_one_widget = get_option( 'widget_royale-news-pro-bottom-news-widget-one' );
-			    $bottom_one_widget[1]['cat'][0] = $beauty_category_id;
-			    update_option( 'widget_royale-news-pro-bottom-news-widget-one', $bottom_one_widget );	
+				$layout_three_widget           = get_option( 'widget_news-layout-widget-three' );
+				$layout_three_widget[1]['cat'] = absint( $photography_category_id );
+				update_option( 'widget_news-layout-widget-three', $layout_three_widget );
 
-			    $bottom_two_widget = get_option( 'widget_royale-news-pro-bottom-news-widget-two' );
-			    $bottom_two_widget[1]['cat'][0] = $fashion_category_id;
-			    update_option( 'widget_royale-news-pro-bottom-news-widget-two', $bottom_two_widget );
+				$bottom_one_widget              = get_option( 'widget_royale-news-pro-bottom-news-widget-one' );
+				$bottom_one_widget[1]['cat'][0] = $beauty_category_id;
+				update_option( 'widget_royale-news-pro-bottom-news-widget-one', $bottom_one_widget );
 
-			    $primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu');  
-			    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+				$bottom_two_widget              = get_option( 'widget_royale-news-pro-bottom-news-widget-two' );
+				$bottom_two_widget[1]['cat'][0] = $fashion_category_id;
+				update_option( 'widget_royale-news-pro-bottom-news-widget-two', $bottom_two_widget );
 
-			    set_theme_mod(
-			     	'nav_menu_locations', 
-			     	array( 
-			     		'primary' => $primary_menu->term_id, 
-			     		'footer' => $footer_menu->term_id,
-			     	)
-			    );	    		
-	    	}
-	    }
+				$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+				$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-		// Assign front page and posts page (blog page).
-		$front_page_id = get_page_by_title( 'Home' );
-		$blog_page_id  = get_page_by_title( 'Blog' );
+				set_theme_mod(
+					'nav_menu_locations',
+					array(
+						'primary' => $primary_menu->term_id,
+						'footer'  => $footer_menu->term_id,
+					)
+				);
+			}
+		}
 
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $front_page_id->ID );
-		update_option( 'page_for_posts', $blog_page_id->ID );
-		update_option( 'themebeez_themes', $installed_demos );
+
+		$front_page = new WP_Query( array( 'pagename' => 'home' ) );
+
+		if ( $front_page->have_posts() ) {
+			while ( $front_page->have_posts() ) {
+				$front_page->the_post();
+				update_option( 'page_on_front', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
+
+		$blog_page = new WP_Query( array( 'pagename' => 'blog' ) );
+
+		if ( $blog_page->have_posts() ) {
+			while ( $blog_page->have_posts() ) {
+				$blog_page->the_post();
+				update_option( 'page_for_posts', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-royale-news.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-royale-news.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Royale_News extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/royale-news/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => __( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'contents.xml',
@@ -26,82 +26,94 @@ class TT_Theme_Demo_Royale_News extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-		$social_menu 	= get_term_by('name', 'Social Menu', 'nav_menu');  
-	    $footer_menu 	= get_term_by('name', 'Footer Menu', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'primary' => $primary_menu->term_id, 
-	     		'social' => $social_menu->term_id,
-	     		'footer' => $footer_menu->term_id,
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$social_menu  = get_term_by( 'name', 'Social Menu', 'nav_menu' );
+		$footer_menu  = get_term_by( 'name', 'Footer Menu', 'nav_menu' );
 
-	    $business_category = get_term_by( 'slug', 'business', 'category' );
-	    $business_category_id = $business_category->term_id;
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'primary' => $primary_menu->term_id,
+				'social'  => $social_menu->term_id,
+				'footer'  => $footer_menu->term_id,
+			)
+		);
 
-	    $politics_category = get_term_by( 'slug', 'politics', 'category' );
-	    $politics_category_id = $politics_category->term_id;
+		$business_category    = get_term_by( 'slug', 'business', 'category' );
+		$business_category_id = $business_category->term_id;
 
-	    $travel_category = get_term_by( 'slug', 'travel', 'category' );
-	    $travel_category_id = $travel_category->term_id;
+		$politics_category    = get_term_by( 'slug', 'politics', 'category' );
+		$politics_category_id = $politics_category->term_id;
 
-	    $sports_category = get_term_by( 'slug', 'sports', 'category' );
-	    $sports_category_id = $sports_category->term_id;
+		$travel_category    = get_term_by( 'slug', 'travel', 'category' );
+		$travel_category_id = $travel_category->term_id;
 
-	    $fashion_category = get_term_by( 'slug', 'fashion', 'category' );
-	    $fashion_category_id = $fashion_category->term_id;
+		$sports_category    = get_term_by( 'slug', 'sports', 'category' );
+		$sports_category_id = $sports_category->term_id;
 
-	    $events_category = get_term_by( 'slug', 'fashion', 'category' );
-	    $events_category_id = $events_category->term_id;
+		$fashion_category    = get_term_by( 'slug', 'fashion', 'category' );
+		$fashion_category_id = $fashion_category->term_id;
 
-	    $technology_category = get_term_by( 'slug', 'technology', 'category' );
-	    $technology_category_id = $technology_category->term_id;
+		$events_category    = get_term_by( 'slug', 'fashion', 'category' );
+		$events_category_id = $events_category->term_id;
 
+		$technology_category    = get_term_by( 'slug', 'technology', 'category' );
+		$technology_category_id = $technology_category->term_id;
 
-	    $banner_widget = get_option('widget_royale-news-main-highlight-two');
+		$banner_widget = get_option( 'widget_royale-news-main-highlight-two' );
 
-	    $banner_widget[1]['cat_1'] = absint( $business_category_id );
-	    $banner_widget[1]['cat_2'] = absint( $politics_category_id );
-	    $banner_widget[1]['cat_3'] = absint( $travel_category_id );
+		$banner_widget[1]['cat_1'] = absint( $business_category_id );
+		$banner_widget[1]['cat_2'] = absint( $politics_category_id );
+		$banner_widget[1]['cat_3'] = absint( $travel_category_id );
 
-	    update_option( 'widget_royale-news-main-highlight-two', $banner_widget );
+		update_option( 'widget_royale-news-main-highlight-two', $banner_widget );
 
+		$first_widget = get_option( 'widget_royale-news-news-layout-widget-one' );
 
-	    $first_widget = get_option( 'widget_royale-news-news-layout-widget-one' );
+		$first_widget[1]['cat'] = absint( $politics_category_id );
 
-	    $first_widget[1]['cat'] = absint( $politics_category_id );
+		$first_widget[2]['cat'] = absint( $fashion_category_id );
 
-	    $first_widget[2]['cat'] = absint( $fashion_category_id );
+		update_option( 'widget_royale-news-news-layout-widget-one', $first_widget );
 
-	    update_option( 'widget_royale-news-news-layout-widget-one', $first_widget );
+		$second_widget = get_option( 'widget_royale-news-news-layout-widget-two' );
 
+		$second_widget[2]['cat'] = absint( $sports_category_id );
 
-	    $second_widget = get_option( 'widget_royale-news-news-layout-widget-two' );
+		$second_widget[3]['cat'] = absint( $technology_category_id );
 
-	    $second_widget[2]['cat'] = absint( $sports_category_id );
+		update_option( 'widget_royale-news-news-layout-widget-two', $second_widget );
 
-	    $second_widget[3]['cat'] = absint( $technology_category_id );
+		$third_widget = get_option( 'widget_royale-news-bottom-news-widget-one' );
 
-	    update_option( 'widget_royale-news-news-layout-widget-two', $second_widget );
+		$third_widget[1]['cat'] = array( absint( $business_category_id ), absint( $travel_category_id ) );
 
-	    $third_widget = get_option( 'widget_royale-news-bottom-news-widget-one' );
+		update_option( 'widget_royale-news-bottom-news-widget-one', $third_widget );
 
-	    $third_widget[1]['cat'] = array( absint( $business_category_id ), absint( $travel_category_id ) ); 
-
-	    update_option( 'widget_royale-news-bottom-news-widget-one', $third_widget );
-
-	    set_theme_mod( 'royale_news_ticker_news_category', $events_category_id );
-
-		// Assign front page and posts page (blog page).
-		$front_page_id = get_page_by_title( 'Home' );
-		$blog_page_id  = get_page_by_title( 'Blog' );
+		set_theme_mod( 'royale_news_ticker_news_category', $events_category_id );
 
 		update_option( 'show_on_front', 'page' );
-		update_option( 'page_on_front', $front_page_id->ID );
-		update_option( 'page_for_posts', $blog_page_id->ID );
-		update_option( 'themebeez_themes', $installed_demos );
+
+		$front_page = new WP_Query( array( 'pagename' => 'home' ) );
+
+		if ( $front_page->have_posts() ) {
+			while ( $front_page->have_posts() ) {
+				$front_page->the_post();
+				update_option( 'page_on_front', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
+
+		$blog_page = new WP_Query( array( 'pagename' => 'blog' ) );
+
+		if ( $blog_page->have_posts() ) {
+			while ( $blog_page->have_posts() ) {
+				$blog_page->the_post();
+				update_option( 'page_for_posts', get_the_ID() );
+			}
+			wp_reset_postdata();
+		}
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-style-blog-fame.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-style-blog-fame.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Style_Blog_Fame extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/style-blog-fame/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Style Blog Fame Demo', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'contents.xml',
@@ -26,24 +26,24 @@ class TT_Theme_Demo_Style_Blog_Fame extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-		$social_menu 	= get_term_by('name', 'Social Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Header Top', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    $banner_cat		= get_term_by( 'slug', 'diy', 'category' );
-	    $banner_cat_id	= $banner_cat->term_id;
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$social_menu  = get_term_by( 'name', 'Social Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Header Top', 'nav_menu' );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $social_menu->term_id,
-	     		'menu-3' => $header_menu->term_id,
-	     	)
-	    );
+		$banner_cat    = get_term_by( 'slug', 'diy', 'category' );
+		$banner_cat_id = $banner_cat->term_id;
 
-	    set_theme_mod( 'styleblog_featured_post_cat', $banner_cat_id );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $social_menu->term_id,
+				'menu-3' => $header_menu->term_id,
+			)
+		);
 
-		update_option( 'themebeez_themes', $installed_demos );
+		set_theme_mod( 'styleblog_featured_post_cat', $banner_cat_id );
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-style-blog.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-style-blog.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_Style_Blog extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/style-blog/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Style Blog Demo', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'contents.xml',
@@ -26,24 +26,24 @@ class TT_Theme_Demo_Style_Blog extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-		$social_menu 	= get_term_by('name', 'Social Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Header Top', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    $banner_cat		= get_term_by( 'slug', 'style', 'category' );
-	    $banner_cat_id	= $banner_cat->term_id;
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$social_menu  = get_term_by( 'name', 'Social Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Header Top', 'nav_menu' );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $social_menu->term_id,
-	     		'menu-3' => $header_menu->term_id,
-	     	)
-	    );
+		$banner_cat    = get_term_by( 'slug', 'style', 'category' );
+		$banner_cat_id = $banner_cat->term_id;
 
-	    set_theme_mod( 'styleblog_featured_post_cat', $banner_cat_id );
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $social_menu->term_id,
+				'menu-3' => $header_menu->term_id,
+			)
+		);
 
-		update_option( 'themebeez_themes', $installed_demos );
+		set_theme_mod( 'styleblog_featured_post_cat', $banner_cat_id );
 	}
 }

--- a/includes/demo-importer/theme-demo/class-tt-theme-demo-styleblog-plus.php
+++ b/includes/demo-importer/theme-demo/class-tt-theme-demo-styleblog-plus.php
@@ -10,7 +10,7 @@ class TT_Theme_Demo_StyleBlog_Plus extends TT_Theme_Demo {
 
 		$server_url = 'https://themebeez.com/demo-contents/style-blog-pro/';
 
-		$demo_urls  = array(
+		$demo_urls = array(
 			array(
 				'import_file_name'           => esc_html__( 'Demo One', 'themebeez-toolkit' ),
 				'import_file_url'            => $server_url . 'demo-one/contents.xml',
@@ -34,7 +34,7 @@ class TT_Theme_Demo_StyleBlog_Plus extends TT_Theme_Demo {
 				'import_customizer_file_url' => $server_url . 'demo-three/customizer.dat',
 				'import_preview_image_url'   => $server_url . 'demo-three/screenshot.png',
 				'demo_url'                   => 'https://themebeez.com/demos/?theme=style-blog-pro-iii',
-			)
+			),
 		);
 
 		return $demo_urls;
@@ -42,53 +42,52 @@ class TT_Theme_Demo_StyleBlog_Plus extends TT_Theme_Demo {
 
 	public static function after_import( $selected_import ) {
 
-		$primary_menu 	= get_term_by('name', 'Main Menu', 'nav_menu'); 
-		$social_menu 	= get_term_by('name', 'Social Menu', 'nav_menu');  
-	    $header_menu 	= get_term_by('name', 'Header Top', 'nav_menu');
-	    $footer_menu 	= get_term_by('name', 'Footer Bottom', 'nav_menu');
+		update_option( 'widget_block', array() );
 
-	    set_theme_mod(
-	     	'nav_menu_locations', 
-	     	array( 
-	     		'menu-1' => $primary_menu->term_id, 
-	     		'menu-2' => $social_menu->term_id,
-	     		'menu-3' => $header_menu->term_id,
-	     		'menu-4' => $footer_menu->term_id
-	     	)
-	    );
+		$primary_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+		$social_menu  = get_term_by( 'name', 'Social Menu', 'nav_menu' );
+		$header_menu  = get_term_by( 'name', 'Header Top', 'nav_menu' );
+		$footer_menu  = get_term_by( 'name', 'Footer Bottom', 'nav_menu' );
 
-	    $import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
+		set_theme_mod(
+			'nav_menu_locations',
+			array(
+				'menu-1' => $primary_menu->term_id,
+				'menu-2' => $social_menu->term_id,
+				'menu-3' => $header_menu->term_id,
+				'menu-4' => $footer_menu->term_id,
+			)
+		);
 
-	    if( !empty( $import_file_name ) ) {
+		$import_file_name = isset( $selected_import['import_file_name'] ) ? $selected_import['import_file_name'] : '';
 
-	    	if( $import_file_name == 'Demo One' ) {
+		if ( ! empty( $import_file_name ) ) {
 
-	    		$fashion_category		= get_term_by( 'slug', 'fashion', 'category' );
-	    		$fashion_category_id	= $fashion_category->term_id;
+			if ( 'Demo One' === $import_file_name ) {
 
-			   	set_theme_mod( 'styleblog_plus_featured_post_cat', $fashion_category_id );
+				$fashion_category    = get_term_by( 'slug', 'fashion', 'category' );
+				$fashion_category_id = $fashion_category->term_id;
 
-	    	} else if( $import_file_name == 'Demo Two' ) {
+				set_theme_mod( 'styleblog_plus_featured_post_cat', $fashion_category_id );
+			} elseif ( 'Demo Two' === $import_file_name ) {
 
-	    		$blog_category		= get_term_by( 'slug', 'blog', 'category' );
-	    		$blog_category_id		= $blog_category->term_id;
+				$blog_category    = get_term_by( 'slug', 'blog', 'category' );
+				$blog_category_id = $blog_category->term_id;
 
-	    		$glamour_category		= get_term_by( 'slug', 'glamour', 'category' );
-	    		$glamour_category_id		= $glamour_category->term_id;
+				$glamour_category    = get_term_by( 'slug', 'glamour', 'category' );
+				$glamour_category_id = $glamour_category->term_id;
 
-	    		$style_category		= get_term_by( 'slug', 'style', 'category' );
-	    		$style_category_id		= $style_category->term_id;
+				$style_category    = get_term_by( 'slug', 'style', 'category' );
+				$style_category_id = $style_category->term_id;
 
-			   	set_theme_mod( 'styleblog_plus_featured_post_cat', array( $blog_category_id, $glamour_category_id, $style_category_id ) );
-	    	} else {
+				set_theme_mod( 'styleblog_plus_featured_post_cat', array( $blog_category_id, $glamour_category_id, $style_category_id ) );
+			} else {
 
-	    		$general_category		= get_term_by( 'slug', 'general', 'category' );
-	    		$general_category_id	= $general_category->term_id;
+				$general_category    = get_term_by( 'slug', 'general', 'category' );
+				$general_category_id = $general_category->term_id;
 
-			   	set_theme_mod( 'styleblog_plus_featured_post_cat', $general_category_id );
-	    	}
-	    }
-
-		update_option( 'themebeez_themes', $installed_demos );
+				set_theme_mod( 'styleblog_plus_featured_post_cat', $general_category_id );
+			}
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 
 Contributors: themebeez
 Tags: themebeez, demo, content, widgets, menus, import, content, demo, data, widgets, settings, themes
-Requires at least: 5.0.0
-Requires PHP: 7.0.0
-Tested up to: 5.9
-Stable tag: 1.2.5
+Requires at least: 5.6
+Requires PHP: 7.4
+Tested up to: 6.2.2
+Stable tag: 1.2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/themebeez-toolkit.php
+++ b/themebeez-toolkit.php
@@ -3,13 +3,17 @@
  * Plugin Name:       Themebeez Toolkit
  * Plugin URI:        https://wordpress.org/plugins/themebeez-toolkit/
  * Description:       A essential toolkit for themes made by www.themebeez.com. This plugin extends themes made by themebeez & adds functionality to import demo data in just a click.
- * Version:           1.2.5
+ * Version:           1.2.6
+ * Requires at least: 5.6
+ * Requires PHP:      7.4
  * Author:            themebeez
  * Author URI:        https://themebeez.com
  * License:           GPL-2.0+
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       themebeez-toolkit
  * Domain Path:       /languages
+ *
+ * @package Themebeez_Toolkit
  */
 
 // If this file is called directly, abort.
@@ -22,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'THEMEBEEZTOOLKIT_VERSION', '1.2.5' );
+define( 'THEMEBEEZTOOLKIT_VERSION', '1.2.6' );
 
 // Define THEMEBEEZTOOLKIT_PLUGIN_FILE.
 if ( ! defined( 'THEMEBEEZTOOLKIT_PLUGIN_FILE' ) ) {
@@ -30,7 +34,7 @@ if ( ! defined( 'THEMEBEEZTOOLKIT_PLUGIN_FILE' ) ) {
 }
 
 
-if( ! defined( 'THEMEBEEZ_TOOLKIT_THEME_PATH' ) ) {
+if ( ! defined( 'THEMEBEEZ_TOOLKIT_THEME_PATH' ) ) {
 	define( 'THEMEBEEZ_TOOLKIT_THEME_PATH', get_parent_theme_file_path() );
 }
 
@@ -91,8 +95,8 @@ if ( ! class_exists( 'Themebeez_Demo_Importer' ) ) {
  * @since 1.0.0
  * @return Themebeez_Demo_Importer
  */
-function TT() {
-	
+function themebeez_demo_importer_init() {
+
 	return Themebeez_Demo_Importer::instance();
 }
 
@@ -100,8 +104,8 @@ $theme = themebeez_toolkit_theme();
 
 $themes = themebeez_toolkit_theme_array();
 
-if( $theme->get('Author') === 'themebeez' && in_array( $theme->get('TextDomain'), $themes ) ) {
+if ( $theme->get( 'Author' ) === 'themebeez' && in_array( $theme->get( 'TextDomain' ), $themes, true ) ) {
 
 	// Global for backwards compatibility.
-	$GLOBALS['themebeez-demo-importer'] = TT();
+	$GLOBALS['themebeez-demo-importer'] = themebeez_demo_importer_init();
 }


### PR DESCRIPTION
- Fixed: Crashing of WooCommerce product importer page when the plugin is active.
- Fixed: PHP Deprecated:  Function get_page_by_title is <strong>deprecated</strong> since version 6.2.0! Use WP_Query instead.
- Fixed: PHP Notice:  Undefined variable: installed_demos.
- Updated: Removed block widgets when importing a demo.