### PR TITLE
🐛 fix: broken access control.

### DIFF
--- a/includes/udp/class-udp-agent.php
+++ b/includes/udp/class-udp-agent.php
@@ -172,6 +172,11 @@ class Udp_Agent {
 	 * @since    1.0.0
 	 */
 	private function process_user_tracking_choice() {
+		// Verify if the user is logged in and has the capability to manage options.
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			wp_safe_redirect( home_url() );
+			exit;
+		}
 
 		$users_choice = isset( $_GET['udp-agent-allow-access'] ) ? sanitize_text_field( wp_unslash( $_GET['udp-agent-allow-access'] ) ) : ''; //phpcs:ignore
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Contributors: themebeez
 Tags: themebeez, demo, content, widgets, menus, import, content, demo, data, widgets, settings, themes
 Requires at least: 5.6
 Requires PHP: 7.4
-Tested up to: 6.8
-Stable tag: 1.3.5
+Tested up to: 6.9.1
+Stable tag: 1.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,120 +85,158 @@ Follow the instruction below to install this plugin:
 
 
 == Changelog ==
+
+= 1.3.6 - 15 February, 2026 =
+
+- Fix: Broken Access Control in UDP Agent (CVSS 5.3). Credits to Legion Hunter. Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook due to missing authorization and nonce check in it's callback function "on_init".
+
 = 1.3.5 - 23 April, 2025 =
+
 - Fixed: Theme info and demo importer issues with deprecated themes.
 
 = 1.3.4 - 18 April, 2025 =
+
 - Fixed:   PHP Notice:  Function _load_textdomain_just_in_time was called icorrectly.
 
 = 1.3.3 - 11 April, 2025 =
+
 - Updated: Simple mega menu support for child theme for Orchid Store.
 
 = 1.3.2 - 30 December, 2024 =
+
 - Added:   Note when no starter templates are displayed.
 - Updated: Language file, themebeez-toolkit.pot.
 
 = 1.3.1 - 27 December, 2024 =
+
 - Updated: Quick links on theme dashboard page.
 
 = 1.3 - 25 December, 2024 =
+
 - Fixed:   PHP errors and warnings.
 - Updated: Theme dashboard page.
 - Removed: Theme dashboard and demo content configurations for deprecated themes. 
 - Removed: Unwanted codes.
 
 = 1.2.6 - 25 July, 2023 =
+
 - Fixed: Crashing of WooCommerce product importer page when the plugin is active.
 - Fixed: PHP Deprecated:  Function get_page_by_title is <strong>deprecated</strong> since version 6.2.0! Use WP_Query instead.
 - Fixed: PHP Notice:  Undefined variable: installed_demos.
 - Updated: Removed block widgets when importing a demo.
 
 = 1.2.5 - 23 January, 2022 =
+
 - Tested: WordPress version 5.9
 - Tested: PHP version 7.4
 
 = 1.2.4 - July 20, 2021 =
+
 - Updated: Style and enqueue for different pages.
 - Modified: Theme notice will be displayed only in the dashboard page.
 - Removed: Unwanted files and folders.
 
 = 1.2.3 - May 08, 2021 =
+
 - Updated: readme.txt file
 
 = 1.2.2 - May 06, 2021 =
+
 - Updated: Demo data base URL
 
 = 1.2.1 - May 23, 2020 =
+
 - Fix: Error in simple mega menu
 
 = 1.2.0 - April 13, 2020 =
+
 - Added: Dashboard widget for displaying blog posts from https://themebeez.com/blog/
 - Added: Changelog to about page tab
 - Added: WPTRT Admin Notices library
 
 = 1.1.9 - January 15, 2019 =
+
 - Removed: Orchid store mega menu js
 - Removed: Public css & js files
 
 = 1.1.8 - December 22, 2019 =
+
 - Fix: Issue with mega menu columns at orchid store pro
 
 = 1.1.7 - December 3, 2019 =
+
 - Minor update
 
 = 1.1.6 - December 1, 2019 =
+
 - Demo import support for Orchid Store Pro
 
 = 1.1.5 - November 3, 2019 =
+
 - Mega menu support for child themes of Orchid Store theme.
 
 = 1.1.4 - September 26, 2019 =
+
 - Added support for Orchid Store theme.
 
 = 1.1.3 - July 29, 2019 =
+
 - Added support for Fascinate theme.
 
 = 1.1.2 - March 6, 2019 =
+
 - Added support for Cream Blog Lite and Cream Blog Pro
 
 = 1.1.1 - April 16, 2019 =
+
 - Added one more demo import support for Royale News Pro
 
 = 1.1.0 - April 15, 2019 =
+
 - Added support for Royale News Lite theme
 - Pro themes links updated
 
 = 1.0.9 - March 07, 2019 =
+
 - Added support for Cream Magazine theme
 - Other fixes
 
 = 1.0.8 - February 25, 2019 =
+
 - Minor Issues Fixed
 - Added support for pro themes
 
 = 1.0.7 - January 8, 2019 =
+
 - Issue with get started button on welcome section of admin page is fixed
 
 = 1.0.6 - January 8, 2019 =
+
 - Addition of inbuilt demo importer
 - OCDI folder and all the demo contents have been removed
 
 = 1.0.5 - December 14, 2018 =
+
 - Changed: PLUGIN_NAME_VERSION to THEMEBEEZTOOLKIT_VERSION
 - Changed: Theme info page demo data import tab message
 
 = 1.0.4 - November 29, 2018 =
+
 - Fix: Issue occuring when child theme gets activated
 
 = 1.0.3 - November 13, 2018 =
+
 - Fix: This plugin hasn’t been tested with the latest 3 major releases of WordPress issue
 - Fix: Verion numbers
 
 = 1.0.2 - November 12, 2018 =
+
 - Theme info and demo content files added for themes Royale News, One Hive and StyleBlog.
 
 = 1.0.1 - October 13, 2018 =
+
 - Fix banner image & icon
 
 = 1.0.0 - October 12, 2018 =
+
 - Initial release 

--- a/themebeez-toolkit.php
+++ b/themebeez-toolkit.php
@@ -3,10 +3,10 @@
  * Plugin Name:       Themebeez Toolkit
  * Plugin URI:        https://wordpress.org/plugins/themebeez-toolkit/
  * Description:       A essential toolkit for themes made by www.themebeez.com. This plugin extends themes made by themebeez & adds functionality to import demo data in just a click.
- * Version:           1.3.5
+ * Version:           1.3.6
  * Requires at least: 5.6
  * Requires PHP:      7.4
- * Tested up to:      6.8
+ * Tested up to:      6.9.1
  * Author:            themebeez
  * Author URI:        https://themebeez.com
  * License:           GPL-2.0+
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'THEMEBEEZTOOLKIT_VERSION', '1.3.5' );
+define( 'THEMEBEEZTOOLKIT_VERSION', '1.3.6' );
 
 // Define THEMEBEEZTOOLKIT_PLUGIN_FILE.
 if ( ! defined( 'THEMEBEEZTOOLKIT_PLUGIN_FILE' ) ) {


### PR DESCRIPTION
Fix: Broken Access Control in UDP Agent (CVSS 5.3). Credits to Legion Hunter. Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook due to missing authorization and nonce check in it's callback function "on_init".